### PR TITLE
Fix --lang bug in prepare-data.py

### DIFF
--- a/scripts/prepare-data.py
+++ b/scripts/prepare-data.py
@@ -215,7 +215,7 @@ if __name__ == '__main__':
 
     if args.lang is None:
         args.lang = args.extensions
-    elif len(args.lang) != args.extensions:
+    elif len(args.lang) != len(args.extensions):
         sys.exit('wrong number of values for parameter --lang')
 
     if args.verbose:


### PR DESCRIPTION
The number of --lang arguments was checked against the actual extensions arguments list instead of its length
